### PR TITLE
Auto create dto childs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -23,5 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial generator class.
 - Support for doc block type casting.
 
+[0.1.2]: https://github.com/anteris-dev/data-transfer-object-factory/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/anteris-dev/data-transfer-object-factory/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/anteris-dev/data-transfer-object-factory/releases/tag/v0.1.0

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2020-12-04
+### Fixed
+- Factory was not generating child DTOs for properties that were typed to a DTO.
+
 ## [0.1.1] - 2020-11-16
 ### Added
 - Stricter type checks for phpDocumentor

--- a/.github/README.md
+++ b/.github/README.md
@@ -27,6 +27,8 @@ $object = DataTransferObjectFactory::make( DataTransferObject::class );
 
 ```
 
+- **Note**: If your DTO contains a property which is cast to another DTO, this will be generated if the fully qualified domain name is used. (e.g. `\Tests\TestData\TestClass`).
+
 You can even fake a collection of DTOs.
 
 ```php

--- a/src/DataTransferObjectFactory.php
+++ b/src/DataTransferObjectFactory.php
@@ -67,6 +67,19 @@ class DataTransferObjectFactory
                 continue;
             }
 
+            // Now that we have checked doc blocks, check for a DTO and generate
+            // one if that is the type of this property.
+            if (
+                ! $docCommentType &&
+                static::isDTO($property->getType()->getName())
+            ) {
+                $dtoParameters[$property->getName()] = static::make(
+                    $property->getType()->getName()
+                );
+
+                continue;
+            }
+
             // Generate a value for properties with types
             // This section gets rid of namespaces when creating the make function
             // BUT if a type was defined back in the docblock, default to that because
@@ -317,7 +330,8 @@ class DataTransferObjectFactory
         $reflectionClass = new ReflectionClass($class);
 
         // This step just ensures we are dealing with a DTO
-        if (! $reflectionClass->newInstanceWithoutConstructor() instanceof DataTransferObject) {
+        // ->newInstanceWithoutConstructor() instanceof DataTransferObject
+        if (! $reflectionClass->isSubclassOf(DataTransferObject::class)) {
             return false;
         }
 

--- a/tests/DataTransferObjectFactoryTest.php
+++ b/tests/DataTransferObjectFactoryTest.php
@@ -6,10 +6,12 @@ use Anteris\DataTransferObjectFactory\DataTransferObjectFactory;
 use DateTime;
 use Exception;
 use PHPUnit\Framework\TestCase;
+use Tests\TestData\TestChildDTO;
 use Tests\TestData\TestClass;
 use Tests\TestData\TestDTO;
 use Tests\TestData\TestDTOCollection;
 use Tests\TestData\TestDTOWithUnknownType;
+use Tests\TestData\TestParentDTO;
 
 class DataTransferObjectFactoryTest extends TestCase
 {
@@ -42,6 +44,24 @@ class DataTransferObjectFactoryTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Unknown data type Carbon!');
         DataTransferObjectFactory::make(TestDTOWithUnknownType::class);
+    }
+
+    /**
+     * @covers Anteris\DataTransferObjectFactory\DataTransferObjectFactory
+     */
+    public function test_it_can_create_dto_with_child_dto()
+    {
+        $dto = DataTransferObjectFactory::make(TestParentDTO::class);
+
+        $this->assertInstanceOf(
+            TestParentDTO::class,
+            $dto
+        );
+
+        $this->assertInstanceOf(
+            TestChildDTO::class,
+            $dto->person
+        );
     }
 
     /**

--- a/tests/TestData/TestChildDTO.php
+++ b/tests/TestData/TestChildDTO.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\TestData;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class TestChildDTO extends DataTransferObject
+{
+    public string $firstName;
+    public string $middleName;
+    public string $lastName;
+}

--- a/tests/TestData/TestClass.php
+++ b/tests/TestData/TestClass.php
@@ -6,7 +6,7 @@ class TestClass
 {
     public int $id;
     public string $text;
-    public DateTime $date;
+    public \DateTime $date;
     public float $float;
     public array $anArray;
     public bool $boolean;

--- a/tests/TestData/TestParentDTO.php
+++ b/tests/TestData/TestParentDTO.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests\TestData;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class TestParentDTO extends DataTransferObject
+{
+    public string $company;
+    public \Tests\TestData\TestChildDTO $person;
+}


### PR DESCRIPTION
# Fixed
- Factory was not generating child DTOs for properties that were typed to a DTO.