### PR TITLE
Add #[MapFrom] support for Spatie DTO objects

### DIFF
--- a/src/Adapter/DataTransferObjectAdapter.php
+++ b/src/Adapter/DataTransferObjectAdapter.php
@@ -3,6 +3,7 @@
 namespace Anteris\DataTransferObjectFactory\Adapter;
 
 use Anteris\DataTransferObjectFactory\Data\PropertyCollection;
+use Anteris\DataTransferObjectFactory\Data\PropertyData;
 use ReflectionClass;
 
 class DataTransferObjectAdapter extends PublicPropertyAdapter
@@ -21,9 +22,24 @@ class DataTransferObjectAdapter extends PublicPropertyAdapter
         $propertiesAndValues = [];
 
         foreach ($properties as $property) {
-            $propertiesAndValues[$property->name] = $property->value;
+            $propertyName = $this->getPropertyName($class, $property);
+
+            $propertiesAndValues[$propertyName] = $property->value;
         }
 
         return $class->newInstanceArgs($propertiesAndValues);
+    }
+
+    private function getPropertyName(ReflectionClass $class, PropertyData $property): string
+    {
+        $attributes = $class->getProperty($property->name)->getAttributes();
+
+        foreach ($attributes as $attribute) {
+            if ($attribute->getName() === \Spatie\DataTransferObject\Attributes\MapFrom::class) {
+                return $attribute->getArguments()[0];
+            }
+        }
+
+        return $property->name;
     }
 }

--- a/tests/Adapter/DataTransferObjectAdapterTest.php
+++ b/tests/Adapter/DataTransferObjectAdapterTest.php
@@ -7,6 +7,7 @@ use Anteris\DataTransferObjectFactory\Data\PropertyCollection;
 use Anteris\DataTransferObjectFactory\Data\PropertyData;
 use Anteris\Tests\DataTransferObjectFactory\Dummy\PhpDto;
 use Anteris\Tests\DataTransferObjectFactory\Dummy\SpatieDto;
+use Anteris\Tests\DataTransferObjectFactory\Dummy\SpatieMappedDto;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -43,6 +44,20 @@ class DataTransferObjectAdapterTest extends TestCase
         $this->assertSame('Casey', $dto->lastName);
         $this->assertSame('aidan.casey@example.com', $dto->email);
         $this->assertSame('123 Test Ave.', $dto->address);
+    }
+
+    public function test_it_can_create_class_with_mapped_properties()
+    {
+        $adapter = new DataTransferObjectAdapter;
+
+        $propertiesNeeded = new PropertyCollection([
+            new PropertyData('firstName', ['string'], 'Aidan'),
+        ]);
+
+        $dto = $adapter->createClass(new ReflectionClass(SpatieMappedDto::class), $propertiesNeeded);
+
+        $this->assertInstanceOf(SpatieMappedDto::class, $dto);
+        $this->assertSame('Aidan', $dto->firstName);
     }
 
     public function test_it_can_get_properties()

--- a/tests/Dummy/SpatieMappedDto.php
+++ b/tests/Dummy/SpatieMappedDto.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Anteris\Tests\DataTransferObjectFactory\Dummy;
+
+use Spatie\DataTransferObject\Attributes\MapFrom;
+use Spatie\DataTransferObject\DataTransferObject;
+
+class SpatieMappedDto extends DataTransferObject
+{
+    #[MapFrom('first_name')]
+    public string $firstName;
+}


### PR DESCRIPTION
Previously this would throw a type error `Cannot assign null to property ... of type ...`:

```php
class MyDto extends DataTransferObject
{
    #[MapFrom('first_name')]
    public string $firstName;
}
```

```php
Factory::new(MyDto::class)->make();
```

This PR adds support for `#[MapFrom]`. When constructing Spatie DTOs the properties may be set from a different argument (defined by the attribute's first parameter).

Overriding still works as expected:
```php
Factory::new(MyDto::class)->make([
    'firstName' => 'Jeffrey',
]);
```